### PR TITLE
Remove Unused Imports in stdio-bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ The MCP server runs by default on localhost port 8181 over SSE. The configuratio
 }
 ```
 
-To use BurpMCP with Claude Desktop, download the `stdio-bridge.py` script and add the following configuration to your `claude_desktop_config.json`. Make sure the host and port match what you configure in BurpMCP.
+To use BurpMCP with Claude Desktop, download the `stdio-bridge.py` script and install the required dependencies:
+
+```sh
+pip3 install typer mcp
+```
+
+Then, add the following configuration to your `claude_desktop_config.json`. Make sure the host and port match what you configure in BurpMCP.
 
 ```json
 {

--- a/stdio-bridge.py
+++ b/stdio-bridge.py
@@ -7,17 +7,10 @@ This allows clients like Claude Desktop that only support STDIO to connect to re
 
 import asyncio
 import logging
-import os
 import sys
 import typer
-from pathlib import Path
-from typing import Any, Optional, Tuple, Dict
+from typing import Any, Optional
 from urllib.parse import urlparse
-
-import anyio
-from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
-import httpx
-
 from mcp import (
     ClientSession, 
     ServerSession, 


### PR DESCRIPTION
Removed unused imports to reduce the number of packages required to run the bridge.